### PR TITLE
Release 1.1.0

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,0 +1,56 @@
+[
+    {
+        "caption": "Preferences",
+        "mnemonic": "n",
+        "id": "preferences",
+        "children":
+        [
+            {
+                "caption": "Package Settings",
+                "mnemonic": "P",
+                "id": "package-settings",
+                "children":
+                [
+                    {
+                        "caption": "SublimeTmux",
+                        "children":
+                        [
+                            {
+                                "command": "open_file",
+                                "args": { "file": "${packages}/SublimeTmux/SublimeTmux.sublime-settings" },
+                                "caption": "Settings – Default"
+                            },
+                            {
+                                "command": "open_file",
+                                "args": { "file": "${packages}/User/SublimeTmux.sublime-settings" },
+                                "caption": "Settings – User"
+                            },
+                            {
+                                "caption": "Settings – More",
+                                "children":
+                                [
+                                    {
+                                        "command": "open_file",
+                                        "args": {
+                                            "file": "${packages}/User/SublimeTmux (Linux).sublime-settings",
+                                            "platform": "Linux"
+                                        },
+                                        "caption": "OS Specific – User"
+                                    },
+                                    {
+                                        "command": "open_file",
+                                        "args": {
+                                            "file": "${packages}/User/SublimeTmux (OSX).sublime-settings",
+                                            "platform": "OSX"
+                                        },
+                                        "caption": "OS Specific – User"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Soon to be available on [Package Control](https://packagecontrol.io/). Until the
 
 ## Usage
 
-For now, *sublime-tmux* requires a your local tmux server to be running. In practice this means it will only run actions whilst you have an open tmux session in your terminal emulator.
+For now, *SublimeTmux* requires a local tmux server to be running. In practice this means it will only run actions whilst you have an open tmux session in your terminal emulator.
 
 Once installed, a number of tmux-related commands are available in the Command Palette, activated with *ctrl*+*shift*+*p*:
 
@@ -26,13 +26,21 @@ Open a new tmux window at the directory of the current file.
 
 Open a new tmux window at the current root project directory.
 
-### Arguments
+### Command arguments
 
 These properties may be set as part of the `args` object for any command.
 
-#### `split` (str)
+| Property | Type | Default | Description |
+| --- | --- | --- | --- |
+| **`split`** | `string`  | `null` | If set, a new pane in the current window will be opened. The direction of the split can be set to either `"horizontal"` or `"vertical"` (default). |
 
-If set, a new pane in the current window will be opened. The direction of the split can be set to either `"horizontal"` or `"vertical"` (default).
+### Package settings
+
+Default, user-level and OS-specific settings files can be accessed under **Preferences > Package Settings > SublimeTmux**.
+
+| Property | Type | Default | Description |
+| --- | --- | --- | --- |
+| **`set_project_window_name`** | `bool`  | `true` | Set whether new windows created with `open_tmux_project_folder` should be created with their name set to that of the directory opened. This is useful to identify multiple window tabs across projects. |
 
 ## Contributing
 

--- a/SublimeTmux.py
+++ b/SublimeTmux.py
@@ -3,6 +3,18 @@ import sublime_plugin
 import os
 import re
 import subprocess
+import sys
+
+def get_setting(key, default=None):
+    settings = sublime.load_settings('SublimeTmux.sublime-settings')
+    os_specific_settings = {}
+
+    if sys.platform == 'darwin':
+        os_specific_settings = sublime.load_settings('SublimeTmux (OSX).sublime-settings')
+    else:
+        os_specific_settings = sublime.load_settings('SublimeTmux (Linux).sublime-settings')
+
+    return os_specific_settings.get(key, settings.get(key, default))
 
 class TmuxCommand():
     def resolve_file_path(self, path):

--- a/SublimeTmux.py
+++ b/SublimeTmux.py
@@ -63,5 +63,10 @@ class OpenTmuxProjectFolderCommand(sublime_plugin.WindowCommand, TmuxCommand):
     def run(self, path=None, split=None):
         path = self.resolve_file_path(path)
         folders = [x for x in self.window.folders() if path.find(x + os.sep) == 0][0:1]
+        path = folders[0]
+        parameters=[]
 
-        self.run_tmux(folders[0], [], split)
+        if get_setting('set_project_window_name', True):
+            parameters.extend(['-n', path.split(os.sep)[-1]])
+
+        self.run_tmux(path, parameters, split)

--- a/SublimeTmux.py
+++ b/SublimeTmux.py
@@ -54,14 +54,14 @@ class TmuxCommand():
             sublime.error_message('tmux: ' + str(exception))
 
 class OpenTmuxCommand(sublime_plugin.WindowCommand, TmuxCommand):
-    def run(self, path=None, parameters=[], split=None):
+    def run(self, path=None, split=None):
         path = self.resolve_file_path(path)
 
-        self.run_tmux(path, parameters, split)
+        self.run_tmux(path, [], split)
 
 class OpenTmuxProjectFolderCommand(sublime_plugin.WindowCommand, TmuxCommand):
-    def run(self, path=None, parameters=[], split=None):
+    def run(self, path=None, split=None):
         path = self.resolve_file_path(path)
         folders = [x for x in self.window.folders() if path.find(x + os.sep) == 0][0:1]
 
-        self.run_tmux(folders[0], parameters, split)
+        self.run_tmux(folders[0], [], split)

--- a/SublimeTmux.sublime-settings
+++ b/SublimeTmux.sublime-settings
@@ -1,0 +1,5 @@
+{
+    // Set whether new windows created with `open_tmux_project_folder` should
+    // be created with their name set to that of the directory opened.
+    "set_project_window_name": true
+}


### PR DESCRIPTION
- Add `set_project_window_name` option and change default window naming behaviour for `open_tmux_project_folder`.
- Add default settings file and Package Settings menu entries
- Update documentation