### PR TITLE
Release 2.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Default, user-level and OS-specific settings files can be accessed under **Prefe
 
 | Property | Type | Default | Description |
 | --- | --- | --- | --- |
+| **`arrange_panes_on_split`** | `bool\|string` | `false` | Set how the active window layout should be updated each time after opening a split pane. A value of `"even"` will evenly distribute all panes in the direction opened. `"tiled"` or `true` will distribute all panes as evenly as possible in both rows and columns. Leave `false` to take no action. |
 | **`set_project_window_name`** | `bool`  | `true` | Set whether new windows created with `open_tmux_project_folder` should be created with their name set to that of the directory opened. This is useful to identify multiple window tabs across projects. |
 
 ## Contributing

--- a/Side Bar.sublime-menu
+++ b/Side Bar.sublime-menu
@@ -10,12 +10,16 @@
         "children": [
             {
                 "caption": "New window",
-                "command": "open_tmux"
+                "command": "open_tmux",
+                "args": {
+                    "paths": []
+                }
             },
             {
                 "caption": "New pane (split vertically)",
                 "command": "open_tmux",
                 "args": {
+                    "paths": [],
                     "split": "vertical"
                 }
             },
@@ -23,6 +27,7 @@
                 "caption": "New pane (split horizontally)",
                 "command": "open_tmux",
                 "args": {
+                    "paths": [],
                     "split": "horizontal"
                 }
             }

--- a/tmux.py
+++ b/tmux.py
@@ -100,12 +100,9 @@ class OpenTmuxCommand(sublime_plugin.WindowCommand, TmuxCommand):
         self.run_tmux(path, [], split)
 
 class OpenTmuxProjectFolderCommand(sublime_plugin.WindowCommand, TmuxCommand):
-    def run(self, path=None, split=None):
+    def run(self, split=None):
         parameters=[]
-
-        if not path:
-            path = self.resolve_file_path()
-
+        path = self.resolve_file_path()
         matched_folders = [x for x in self.window.folders() if path.find(x) == 0]
 
         if len(matched_folders):

--- a/tmux.py
+++ b/tmux.py
@@ -21,11 +21,7 @@ def get_setting(key, default=None):
 class TmuxCommand():
     def resolve_file_path(self):
         if self.window.active_view().file_name():
-            return re.sub(
-                re.compile('{0}[^{0}]+$'.format(os.sep)),
-                os.sep,
-                self.window.active_view().file_name()
-            )
+            return os.path.dirname(self.window.active_view().file_name())
         elif len(self.window.folders()):
             return self.window.folders()[0]
         else:

--- a/tmux.py
+++ b/tmux.py
@@ -46,6 +46,19 @@ class TmuxCommand():
 
         return [dict(zip(parts, line.strip().split(' '))) for line in io.TextIOWrapper(list_sessions.stdout)]
 
+    def update_window_layout(self):
+        args = ['tmux', 'select-layout']
+
+        if get_setting('arrange_panes_on_split') == 'even':
+            args.append('even-' + ('horizontal' if '-h' in self.command_args else 'vertical'))
+        else:
+            args.append('tiled')
+
+        if '-t' in self.command_args:
+            args.extend(['-t', self.command_args[self.command_args.index('-t') + 1]])
+
+        subprocess.Popen(args)
+
     def format_session_choices(self, sessions):
         return list(map(
             lambda session: [
@@ -87,6 +100,10 @@ class TmuxCommand():
         try:
             for path in self.paths:
                 subprocess.Popen(self.command_args + ['-c', path])
+
+            if 'split-window' in self.command_args and get_setting('arrange_panes_on_split'):
+                self.update_window_layout()
+
         except Exception as exception:
             sublime.error_message('tmux: ' + str(exception))
 

--- a/tmux.py
+++ b/tmux.py
@@ -93,11 +93,14 @@ class TmuxCommand():
             sublime.error_message('tmux: ' + str(exception))
 
 class OpenTmuxCommand(sublime_plugin.WindowCommand, TmuxCommand):
-    def run(self, path=None, split=None):
-        if not path:
-            path = self.resolve_file_path()
+    def run(self, paths=[], split=None):
+        dirs = [os.path.dirname(path) if not os.path.isdir(path) else path for path in paths]
 
-        self.run_tmux(path, [], split)
+        if not len(dirs):
+            dirs.append(self.resolve_file_path())
+
+        for path in dirs:
+            self.run_tmux(path, [], split)
 
 class OpenTmuxProjectFolderCommand(sublime_plugin.WindowCommand, TmuxCommand):
     def run(self, split=None):

--- a/tmux.py
+++ b/tmux.py
@@ -63,7 +63,7 @@ class TmuxCommand():
         self.command_args.extend(['-t', self.attached_sessions[index]['name'] + ':'])
         self.execute()
 
-    def run_tmux(self, path, parameters, split):
+    def run_tmux(self, parameters, split):
         try:
             if self.check_tmux_status():
                 self.attached_sessions = list(filter(lambda x: int(x['attached']), self.get_active_tmux_sessions()))
@@ -72,9 +72,6 @@ class TmuxCommand():
 
                 if split == 'horizontal':
                     self.command_args.append('-h')
-
-                if path:
-                    self.command_args.extend(['-c', path])
 
                 if len(self.attached_sessions) > 1:
                     return self.window.show_quick_panel(
@@ -88,30 +85,31 @@ class TmuxCommand():
 
     def execute(self):
         try:
-            subprocess.Popen(self.command_args)
+            for path in self.paths:
+                subprocess.Popen(self.command_args + ['-c', path])
         except Exception as exception:
             sublime.error_message('tmux: ' + str(exception))
 
 class OpenTmuxCommand(sublime_plugin.WindowCommand, TmuxCommand):
     def run(self, paths=[], split=None):
-        dirs = [os.path.dirname(path) if not os.path.isdir(path) else path for path in paths]
+        self.paths = [os.path.dirname(path) if not os.path.isdir(path) else path for path in paths]
 
-        if not len(dirs):
-            dirs.append(self.resolve_file_path())
+        if not len(self.paths):
+            self.paths.append(self.resolve_file_path())
 
-        for path in dirs:
-            self.run_tmux(path, [], split)
+        self.run_tmux([], split)
 
 class OpenTmuxProjectFolderCommand(sublime_plugin.WindowCommand, TmuxCommand):
     def run(self, split=None):
         parameters=[]
         path = self.resolve_file_path()
-        matched_folders = [x for x in self.window.folders() if path.find(x) == 0]
+        matched_dirs = [x for x in self.window.folders() if path.find(x) == 0]
 
-        if len(matched_folders):
-            path = matched_folders[0]
+        if len(matched_dirs):
+            path = matched_dirs[0]
 
             if get_setting('set_project_window_name', True):
                 parameters.extend(['-n', path.split(os.sep)[-1]])
 
-        self.run_tmux(path, parameters, split)
+        self.paths = [path]
+        self.run_tmux(parameters, split)

--- a/tmux.sublime-settings
+++ b/tmux.sublime-settings
@@ -1,4 +1,11 @@
 {
+    // Set how the active window layout should be updated each time after
+    // opening a split pane. A value of "even" will evenly distribute all panes
+    // in the direction opened. "tiled" or `true` will distribute all panes as
+    // evenly as possible in both rows and columns. Leave `false` to take no
+    // action.
+    "arrange_panes_on_split": false,
+
     // Set whether new windows created with `open_tmux_project_folder` should
     // be created with their name set to that of the directory opened.
     "set_project_window_name": true


### PR DESCRIPTION
- Fix behaviour when invoking `open_tmux` from a selected folder in the sidebar, allow multiple paths to be opened at once.
- Add `arrange_panes_on_split` package setting to define automatic pane arrangement behaviour on split. Configurable with two active options for distributing: `"even"` and `"tiled"`.