### PR TITLE
Add snapshot tests for command output

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,21 @@
+import io
+from unittest import mock
+
+def mock_process_call(attrs):
+    process_mock = mock.Mock()
+    process_mock.configure_mock(**attrs)
+
+    return process_mock
+
+def mock_tmux_subproc_events():
+    # `tmux info`
+    yield mock_process_call({'returncode': 0})
+
+    # `tmux list-sessions`
+    yield mock_process_call({
+        'returncode': 0,
+        'stdout': io.BufferedReader(io.BytesIO(b'0 1 1513966319 1 150 34\n'))
+    })
+
+    while True:
+        yield mock_process_call({'returncode': 0})

--- a/tests/snapshots/snap_test_open_tmux.py
+++ b/tests/snapshots/snap_test_open_tmux.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+# snapshottest: v1 - https://goo.gl/zC4yUc
+from __future__ import unicode_literals
+
+from snapshottest import Snapshot
+
+
+snapshots = Snapshot()
+
+snapshots['TestOpenTmuxCommand::test_run_current_file 1'] = (
+    [
+        'tmux',
+        'new-window',
+        '-c',
+        '~/example-project/src'
+    ]
+)
+
+snapshots['TestOpenTmuxCommand::test_run_split_horizontal 1'] = (
+    [
+        'tmux',
+        'split-window',
+        '-h',
+        '-c',
+        '~/example-project/src'
+    ]
+)
+
+snapshots['TestOpenTmuxCommand::test_run_split_vertical 1'] = (
+    [
+        'tmux',
+        'split-window',
+        '-c',
+        '~/example-project/src'
+    ]
+)

--- a/tests/snapshots/snap_test_open_tmux.py
+++ b/tests/snapshots/snap_test_open_tmux.py
@@ -16,6 +16,24 @@ snapshots['TestOpenTmuxCommand::test_run_current_file 1'] = (
     ]
 )
 
+snapshots['TestOpenTmuxCommand::test_run_split_arrange_tiled 1'] = [
+    (
+        [
+            'tmux',
+            'split-window',
+            '-c',
+            '/home/user/example-project/src'
+        ]
+    ),
+    (
+        [
+            'tmux',
+            'select-layout',
+            'tiled'
+        ]
+    )
+]
+
 snapshots['TestOpenTmuxCommand::test_run_split_horizontal 1'] = (
     [
         'tmux',
@@ -26,6 +44,25 @@ snapshots['TestOpenTmuxCommand::test_run_split_horizontal 1'] = (
     ]
 )
 
+snapshots['TestOpenTmuxCommand::test_run_split_horizontal_even 1'] = [
+    (
+        [
+            'tmux',
+            'split-window',
+            '-h',
+            '-c',
+            '/home/user/example-project/src'
+        ]
+    ),
+    (
+        [
+            'tmux',
+            'select-layout',
+            'even-horizontal'
+        ]
+    )
+]
+
 snapshots['TestOpenTmuxCommand::test_run_split_vertical 1'] = (
     [
         'tmux',
@@ -34,6 +71,24 @@ snapshots['TestOpenTmuxCommand::test_run_split_vertical 1'] = (
         '/home/user/example-project/src'
     ]
 )
+
+snapshots['TestOpenTmuxCommand::test_run_split_vertical_even 1'] = [
+    (
+        [
+            'tmux',
+            'split-window',
+            '-c',
+            '/home/user/example-project/src'
+        ]
+    ),
+    (
+        [
+            'tmux',
+            'select-layout',
+            'even-vertical'
+        ]
+    )
+]
 
 snapshots['TestOpenTmuxCommand::test_run_unsaved_file_inside_project 1'] = (
     [

--- a/tests/snapshots/snap_test_open_tmux.py
+++ b/tests/snapshots/snap_test_open_tmux.py
@@ -34,3 +34,31 @@ snapshots['TestOpenTmuxCommand::test_run_split_vertical 1'] = (
         '~/example-project/src'
     ]
 )
+
+snapshots['TestOpenTmuxCommand::test_run_with_paths_argument 1'] = (
+    [
+        'tmux',
+        'new-window',
+        '-c',
+        '~/example-project/tests'
+    ]
+)
+
+snapshots['TestOpenTmuxCommand::test_run_with_paths_argument_multiple 1'] = [
+    (
+        [
+            'tmux',
+            'new-window',
+            '-c',
+            '~/example-project/docs'
+        ]
+    ),
+    (
+        [
+            'tmux',
+            'new-window',
+            '-c',
+            '~/example-project/tests'
+        ]
+    )
+]

--- a/tests/snapshots/snap_test_open_tmux.py
+++ b/tests/snapshots/snap_test_open_tmux.py
@@ -12,7 +12,7 @@ snapshots['TestOpenTmuxCommand::test_run_current_file 1'] = (
         'tmux',
         'new-window',
         '-c',
-        '~/example-project/src'
+        '/home/user/example-project/src'
     ]
 )
 
@@ -22,7 +22,7 @@ snapshots['TestOpenTmuxCommand::test_run_split_horizontal 1'] = (
         'split-window',
         '-h',
         '-c',
-        '~/example-project/src'
+        '/home/user/example-project/src'
     ]
 )
 
@@ -31,7 +31,25 @@ snapshots['TestOpenTmuxCommand::test_run_split_vertical 1'] = (
         'tmux',
         'split-window',
         '-c',
-        '~/example-project/src'
+        '/home/user/example-project/src'
+    ]
+)
+
+snapshots['TestOpenTmuxCommand::test_run_unsaved_file_inside_project 1'] = (
+    [
+        'tmux',
+        'new-window',
+        '-c',
+        '/home/user/example-project'
+    ]
+)
+
+snapshots['TestOpenTmuxCommand::test_run_unsaved_file_outside_project 1'] = (
+    [
+        'tmux',
+        'new-window',
+        '-c',
+        '/home/user'
     ]
 )
 
@@ -40,7 +58,7 @@ snapshots['TestOpenTmuxCommand::test_run_with_paths_argument 1'] = (
         'tmux',
         'new-window',
         '-c',
-        '~/example-project/tests'
+        '/home/user/example-project/tests'
     ]
 )
 
@@ -50,7 +68,7 @@ snapshots['TestOpenTmuxCommand::test_run_with_paths_argument_multiple 1'] = [
             'tmux',
             'new-window',
             '-c',
-            '~/example-project/docs'
+            '/home/user/example-project/docs'
         ]
     ),
     (
@@ -58,7 +76,7 @@ snapshots['TestOpenTmuxCommand::test_run_with_paths_argument_multiple 1'] = [
             'tmux',
             'new-window',
             '-c',
-            '~/example-project/tests'
+            '/home/user/example-project/tests'
         ]
     )
 ]

--- a/tests/snapshots/snap_test_open_tmux_project_folder.py
+++ b/tests/snapshots/snap_test_open_tmux_project_folder.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+# snapshottest: v1 - https://goo.gl/zC4yUc
+from __future__ import unicode_literals
+
+from snapshottest import Snapshot
+
+
+snapshots = Snapshot()
+
+snapshots['TestOpenTmuxProjectFolderCommand::test_run_current_file 1'] = (
+    [
+        'tmux',
+        'new-window',
+        '-n',
+        'example-project',
+        '-c',
+        '/home/user/example-project'
+    ]
+)
+
+snapshots['TestOpenTmuxProjectFolderCommand::test_run_secondary_folder 1'] = (
+    [
+        'tmux',
+        'new-window',
+        '-n',
+        'secondary-folder',
+        '-c',
+        '/home/user/secondary-folder'
+    ]
+)
+
+snapshots['TestOpenTmuxProjectFolderCommand::test_run_unsaved_file 1'] = (
+    [
+        'tmux',
+        'new-window',
+        '-n',
+        'example-project',
+        '-c',
+        '/home/user/example-project'
+    ]
+)
+
+snapshots['TestOpenTmuxProjectFolderCommand::test_run_window_name_unset 1'] = (
+    [
+        'tmux',
+        'new-window',
+        '-c',
+        '/home/user/example-project'
+    ]
+)

--- a/tests/test_open_tmux.py
+++ b/tests/test_open_tmux.py
@@ -1,0 +1,53 @@
+import sublime
+import io
+from unittest import mock
+import snapshottest
+
+def mock_process_call(attrs):
+    mock_process = mock.Mock()
+    mock_process.configure_mock(**attrs)
+
+    return mock_process
+
+class TestOpenTmuxCommand(snapshottest.TestCase):
+    @mock.patch('subprocess.Popen')
+    def test_run_current_file(self, mock_subproc_popen):
+        mock_subproc_popen.side_effect = [
+            mock_process_call({'returncode': 0}),
+            mock_process_call({'returncode': 0, 'stdout': io.BufferedReader(io.BytesIO(b'0 1 1513966319 1 206 51\n'))}),
+            mock_process_call({'returncode': 0})
+        ]
+
+        with mock.patch('os.path.dirname') as mock_os_dirname:
+            mock_os_dirname.return_value = '~/example-project/src'
+            sublime.active_window().run_command('open_tmux')
+
+        self.assertMatchSnapshot(mock_subproc_popen.call_args[0])
+
+    @mock.patch('subprocess.Popen')
+    def test_run_split_vertical(self, mock_subproc_popen):
+        mock_subproc_popen.side_effect = [
+            mock_process_call({'returncode': 0}),
+            mock_process_call({'returncode': 0, 'stdout': io.BufferedReader(io.BytesIO(b'0 1 1513966319 1 206 51\n'))}),
+            mock_process_call({'returncode': 0})
+        ]
+
+        with mock.patch('os.path.dirname') as mock_os_dirname:
+            mock_os_dirname.return_value = '~/example-project/src'
+            sublime.active_window().run_command('open_tmux', { 'split': 'vertical' })
+
+        self.assertMatchSnapshot(mock_subproc_popen.call_args[0])
+
+    @mock.patch('subprocess.Popen')
+    def test_run_split_horizontal(self, mock_subproc_popen):
+        mock_subproc_popen.side_effect = [
+            mock_process_call({'returncode': 0}),
+            mock_process_call({'returncode': 0, 'stdout': io.BufferedReader(io.BytesIO(b'0 1 1513966319 1 206 51\n'))}),
+            mock_process_call({'returncode': 0})
+        ]
+
+        with mock.patch('os.path.dirname') as mock_os_dirname:
+            mock_os_dirname.return_value = '~/example-project/src'
+            sublime.active_window().run_command('open_tmux', { 'split': 'horizontal' })
+
+        self.assertMatchSnapshot(mock_subproc_popen.call_args[0])

--- a/tests/test_open_tmux.py
+++ b/tests/test_open_tmux.py
@@ -4,50 +4,50 @@ from unittest import mock
 import snapshottest
 
 def mock_process_call(attrs):
-    mock_process = mock.Mock()
-    mock_process.configure_mock(**attrs)
+    process_mock = mock.Mock()
+    process_mock.configure_mock(**attrs)
 
-    return mock_process
+    return process_mock
+
+def mock_tmux_subproc_calls():
+    # `tmux info`
+    yield mock_process_call({'returncode': 0})
+
+    # `tmux list-sessions`
+    yield mock_process_call({
+        'returncode': 0,
+        'stdout': io.BufferedReader(io.BytesIO(b'0 1 1513966319 1 150 34\n'))
+    })
+
+    # Later commands
+    while True:
+        yield mock_process_call({'returncode': 0})
 
 class TestOpenTmuxCommand(snapshottest.TestCase):
-    @mock.patch('subprocess.Popen')
-    def test_run_current_file(self, mock_subproc_popen):
-        mock_subproc_popen.side_effect = [
-            mock_process_call({'returncode': 0}),
-            mock_process_call({'returncode': 0, 'stdout': io.BufferedReader(io.BytesIO(b'0 1 1513966319 1 206 51\n'))}),
-            mock_process_call({'returncode': 0})
-        ]
+    def setUp(self):
+        self.subproc_popen_mock = mock.patch('subprocess.Popen').start()
+        self.subproc_popen_mock.side_effect = mock_tmux_subproc_calls()
 
-        with mock.patch('os.path.dirname') as mock_os_dirname:
-            mock_os_dirname.return_value = '~/example-project/src'
+    def tearDown(self):
+        mock.patch.stopall()
+
+    def test_run_current_file(self):
+        with mock.patch('os.path.dirname') as os_dirname_mock:
+            os_dirname_mock.return_value = '~/example-project/src'
             sublime.active_window().run_command('open_tmux')
 
-        self.assertMatchSnapshot(mock_subproc_popen.call_args[0])
+        self.assertMatchSnapshot(self.subproc_popen_mock.call_args[0])
 
-    @mock.patch('subprocess.Popen')
-    def test_run_split_vertical(self, mock_subproc_popen):
-        mock_subproc_popen.side_effect = [
-            mock_process_call({'returncode': 0}),
-            mock_process_call({'returncode': 0, 'stdout': io.BufferedReader(io.BytesIO(b'0 1 1513966319 1 206 51\n'))}),
-            mock_process_call({'returncode': 0})
-        ]
-
-        with mock.patch('os.path.dirname') as mock_os_dirname:
-            mock_os_dirname.return_value = '~/example-project/src'
+    def test_run_split_vertical(self):
+        with mock.patch('os.path.dirname') as os_dirname_mock:
+            os_dirname_mock.return_value = '~/example-project/src'
             sublime.active_window().run_command('open_tmux', { 'split': 'vertical' })
 
-        self.assertMatchSnapshot(mock_subproc_popen.call_args[0])
+        self.assertMatchSnapshot(self.subproc_popen_mock.call_args[0])
 
-    @mock.patch('subprocess.Popen')
-    def test_run_split_horizontal(self, mock_subproc_popen):
-        mock_subproc_popen.side_effect = [
-            mock_process_call({'returncode': 0}),
-            mock_process_call({'returncode': 0, 'stdout': io.BufferedReader(io.BytesIO(b'0 1 1513966319 1 206 51\n'))}),
-            mock_process_call({'returncode': 0})
-        ]
-
-        with mock.patch('os.path.dirname') as mock_os_dirname:
-            mock_os_dirname.return_value = '~/example-project/src'
+    def test_run_split_horizontal(self):
+        with mock.patch('os.path.dirname') as os_dirname_mock:
+            os_dirname_mock.return_value = '~/example-project/src'
             sublime.active_window().run_command('open_tmux', { 'split': 'horizontal' })
 
-        self.assertMatchSnapshot(mock_subproc_popen.call_args[0])
+        self.assertMatchSnapshot(self.subproc_popen_mock.call_args[0])

--- a/tests/test_open_tmux.py
+++ b/tests/test_open_tmux.py
@@ -38,6 +38,22 @@ class TestOpenTmuxCommand(snapshottest.TestCase):
 
         self.assertMatchSnapshot(self.subproc_popen_mock.call_args[0])
 
+    def test_run_with_paths_argument(self):
+        sublime.active_window().run_command('open_tmux', {'paths': ['~/example-project/tests/snapshots']})
+
+        self.assertMatchSnapshot(self.subproc_popen_mock.call_args[0])
+
+    def test_run_with_paths_argument_multiple(self):
+        with mock.patch('os.path.isdir') as os_isdir_mock:
+            os_isdir_mock.side_effect = [True, False]
+            sublime.active_window().run_command('open_tmux', {'paths': [
+                '~/example-project/docs',
+                '~/example-project/tests/test.py'
+            ]})
+
+        self.assertEqual(self.subproc_popen_mock.call_count, 4)
+        self.assertMatchSnapshot([args[0] for args in self.subproc_popen_mock.call_args_list[-2:]])
+
     def test_run_split_vertical(self):
         with mock.patch('os.path.dirname') as os_dirname_mock:
             os_dirname_mock.return_value = '~/example-project/src'

--- a/tests/test_open_tmux.py
+++ b/tests/test_open_tmux.py
@@ -93,3 +93,33 @@ class TestOpenTmuxCommand(snapshottest.TestCase):
             sublime.active_window().run_command('open_tmux', { 'split': 'horizontal' })
 
         self.assertMatchSnapshot(self.subproc_popen_mock.call_args[0])
+
+    @mock.patch('sublime.load_settings')
+    def test_run_split_vertical_even(self, mock_load_settings):
+        mock_load_settings.return_value = {'arrange_panes_on_split': 'even'}
+
+        with mock.patch('os.path.dirname') as os_dirname_mock:
+            os_dirname_mock.return_value = '/home/user/example-project/src'
+            sublime.active_window().run_command('open_tmux', { 'split': 'vertical' })
+
+        self.assertMatchSnapshot([args[0] for args in self.subproc_popen_mock.call_args_list[-2:]])
+
+    @mock.patch('sublime.load_settings')
+    def test_run_split_horizontal_even(self, mock_load_settings):
+        mock_load_settings.return_value = {'arrange_panes_on_split': 'even'}
+
+        with mock.patch('os.path.dirname') as os_dirname_mock:
+            os_dirname_mock.return_value = '/home/user/example-project/src'
+            sublime.active_window().run_command('open_tmux', { 'split': 'horizontal' })
+
+        self.assertMatchSnapshot([args[0] for args in self.subproc_popen_mock.call_args_list[-2:]])
+
+    @mock.patch('sublime.load_settings')
+    def test_run_split_arrange_tiled(self, mock_load_settings):
+        mock_load_settings.return_value = {'arrange_panes_on_split': 'tiled'}
+
+        with mock.patch('os.path.dirname') as os_dirname_mock:
+            os_dirname_mock.return_value = '/home/user/example-project/src'
+            sublime.active_window().run_command('open_tmux', { 'split': 'vertical' })
+
+        self.assertMatchSnapshot([args[0] for args in self.subproc_popen_mock.call_args_list[-2:]])

--- a/tests/test_open_tmux.py
+++ b/tests/test_open_tmux.py
@@ -33,13 +33,13 @@ class TestOpenTmuxCommand(snapshottest.TestCase):
 
     def test_run_current_file(self):
         with mock.patch('os.path.dirname') as os_dirname_mock:
-            os_dirname_mock.return_value = '~/example-project/src'
+            os_dirname_mock.return_value = '/home/user/example-project/src'
             sublime.active_window().run_command('open_tmux')
 
         self.assertMatchSnapshot(self.subproc_popen_mock.call_args[0])
 
     def test_run_with_paths_argument(self):
-        sublime.active_window().run_command('open_tmux', {'paths': ['~/example-project/tests/snapshots']})
+        sublime.active_window().run_command('open_tmux', {'paths': ['/home/user/example-project/tests/snapshots']})
 
         self.assertMatchSnapshot(self.subproc_popen_mock.call_args[0])
 
@@ -47,23 +47,49 @@ class TestOpenTmuxCommand(snapshottest.TestCase):
         with mock.patch('os.path.isdir') as os_isdir_mock:
             os_isdir_mock.side_effect = [True, False]
             sublime.active_window().run_command('open_tmux', {'paths': [
-                '~/example-project/docs',
-                '~/example-project/tests/test.py'
+                '/home/user/example-project/docs',
+                '/home/user/example-project/tests/test.py'
             ]})
 
         self.assertEqual(self.subproc_popen_mock.call_count, 4)
         self.assertMatchSnapshot([args[0] for args in self.subproc_popen_mock.call_args_list[-2:]])
 
+    def test_run_unsaved_file_inside_project(self):
+        view = sublime.active_window().new_file()
+
+        with mock.patch('sublime.Window.folders') as window_folders_mock:
+            window_folders_mock.return_value = [
+                '/home/user/example-project',
+                '/home/user/secondary-folder'
+            ]
+            sublime.active_window().run_command('open_tmux')
+
+        self.assertMatchSnapshot(self.subproc_popen_mock.call_args[0])
+        view.window().run_command("close_file")
+
+    def test_run_unsaved_file_outside_project(self):
+        view = sublime.active_window().new_file()
+
+        with mock.patch('sublime.Window.folders') as window_folders_mock:
+            window_folders_mock.return_value = []
+
+            with mock.patch('os.path.expanduser') as home_dir_mock:
+                home_dir_mock.return_value = '/home/user'
+                sublime.active_window().run_command('open_tmux')
+
+        self.assertMatchSnapshot(self.subproc_popen_mock.call_args[0])
+        view.window().run_command("close_file")
+
     def test_run_split_vertical(self):
         with mock.patch('os.path.dirname') as os_dirname_mock:
-            os_dirname_mock.return_value = '~/example-project/src'
+            os_dirname_mock.return_value = '/home/user/example-project/src'
             sublime.active_window().run_command('open_tmux', { 'split': 'vertical' })
 
         self.assertMatchSnapshot(self.subproc_popen_mock.call_args[0])
 
     def test_run_split_horizontal(self):
         with mock.patch('os.path.dirname') as os_dirname_mock:
-            os_dirname_mock.return_value = '~/example-project/src'
+            os_dirname_mock.return_value = '/home/user/example-project/src'
             sublime.active_window().run_command('open_tmux', { 'split': 'horizontal' })
 
         self.assertMatchSnapshot(self.subproc_popen_mock.call_args[0])

--- a/tests/test_open_tmux_project_folder.py
+++ b/tests/test_open_tmux_project_folder.py
@@ -1,32 +1,13 @@
 import sublime
-import io
 from unittest import mock
 import snapshottest
 
-def mock_process_call(attrs):
-    process_mock = mock.Mock()
-    process_mock.configure_mock(**attrs)
-
-    return process_mock
-
-def mock_tmux_subproc_calls():
-    # `tmux info`
-    yield mock_process_call({'returncode': 0})
-
-    # `tmux list-sessions`
-    yield mock_process_call({
-        'returncode': 0,
-        'stdout': io.BufferedReader(io.BytesIO(b'0 1 1513966319 1 150 34\n'))
-    })
-
-    # Later commands
-    while True:
-        yield mock_process_call({'returncode': 0})
+from helpers import mock_tmux_subproc_events
 
 class TestOpenTmuxProjectFolderCommand(snapshottest.TestCase):
     def setUp(self):
         self.subproc_popen_mock = mock.patch('subprocess.Popen').start()
-        self.subproc_popen_mock.side_effect = mock_tmux_subproc_calls()
+        self.subproc_popen_mock.side_effect = mock_tmux_subproc_events()
 
         self.window_folders_mock = mock.patch('sublime.Window.folders').start()
         self.window_folders_mock.return_value = [
@@ -54,9 +35,9 @@ class TestOpenTmuxProjectFolderCommand(snapshottest.TestCase):
     def test_run_unsaved_file(self):
         view = sublime.active_window().new_file()
         sublime.active_window().run_command('open_tmux_project_folder')
+        view.window().run_command('close_file')
 
         self.assertMatchSnapshot(self.subproc_popen_mock.call_args[0])
-        view.window().run_command("close_file")
 
     @mock.patch('sublime.load_settings')
     def test_run_window_name_unset(self, mock_load_settings):

--- a/tests/test_open_tmux_project_folder.py
+++ b/tests/test_open_tmux_project_folder.py
@@ -1,0 +1,64 @@
+import sublime
+import io
+from unittest import mock
+import snapshottest
+
+def mock_process_call(attrs):
+    process_mock = mock.Mock()
+    process_mock.configure_mock(**attrs)
+
+    return process_mock
+
+def mock_tmux_subproc_calls():
+    # `tmux info`
+    yield mock_process_call({'returncode': 0})
+
+    # `tmux list-sessions`
+    yield mock_process_call({
+        'returncode': 0,
+        'stdout': io.BufferedReader(io.BytesIO(b'0 1 1513966319 1 150 34\n'))
+    })
+
+    # Later commands
+    while True:
+        yield mock_process_call({'returncode': 0})
+
+class TestOpenTmuxProjectFolderCommand(snapshottest.TestCase):
+    def setUp(self):
+        self.subproc_popen_mock = mock.patch('subprocess.Popen').start()
+        self.subproc_popen_mock.side_effect = mock_tmux_subproc_calls()
+
+        self.window_folders_mock = mock.patch('sublime.Window.folders').start()
+        self.window_folders_mock.return_value = [
+            '/home/user/example-project',
+            '/home/user/secondary-folder'
+        ]
+
+    def tearDown(self):
+        mock.patch.stopall()
+
+    def test_run_current_file(self):
+        with mock.patch('sublime.View.file_name') as file_name_mock:
+            file_name_mock.return_value = '/home/user/example-project/README.md'
+            sublime.active_window().run_command('open_tmux_project_folder')
+
+        self.assertMatchSnapshot(self.subproc_popen_mock.call_args[0])
+
+    def test_run_secondary_folder(self):
+        with mock.patch('sublime.View.file_name') as file_name_mock:
+            file_name_mock.return_value = '/home/user/secondary-folder/src/main.py'
+            sublime.active_window().run_command('open_tmux_project_folder')
+
+        self.assertMatchSnapshot(self.subproc_popen_mock.call_args[0])
+
+    def test_run_unsaved_file(self):
+        view = sublime.active_window().new_file()
+        sublime.active_window().run_command('open_tmux_project_folder')
+
+        self.assertMatchSnapshot(self.subproc_popen_mock.call_args[0])
+        view.window().run_command("close_file")
+
+    @mock.patch('sublime.load_settings')
+    def test_run_window_name_unset(self, mock_load_settings):
+        mock_load_settings.return_value = {'set_project_window_name': False}
+        self.test_run_current_file()

--- a/tmux.py
+++ b/tmux.py
@@ -27,7 +27,7 @@ class TmuxCommand():
         else:
             sublime.status_message('tmux: Could not resolve file path - opening at home directory')
 
-            return '~/'
+            return os.path.expanduser('~')
 
     def check_tmux_status(self):
         tmux_status = subprocess.Popen(['tmux', 'info'])


### PR DESCRIPTION
- Add test classes to cover most scenarios for `open_tmux` and `open_tmux_project_folder` commands. Authored using the `snapshottest` library to write snapshots of complete command arguments, to identify when future code changes affect these.
- ~Configure CircleCI builds in both Linux and macOS test environments.~ To do in #12.